### PR TITLE
Fix the build with slibtool.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,6 @@ pkgconfig_DATA = libspiro.pc
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CFLAGS = $(WCFLAGS) $(LS_CFLAGS)
-AM_LDFLAGS = $(WLSLIB) $(LS_LIB) -no-undefined --mode=link
 
 LIBTOOL_DEPS = @LIBTOOL_DEPS@
 
@@ -23,9 +22,10 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-verbose_lib --enable-test_inputs --enable-t
 
 lib_LTLIBRARIES = libspiro.la
 
-libspiro_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(LIBSPIRO_VERSION)
-libspiro_la_SOURCES = spiro.c bezctx.c spiroentrypoints.c
-libspiro_la.$(OBJEXT): bezctx.h bezctx_intf.h spiro.h spiroentrypoints.h
+libspiro_la_LIBADD = $(WLSLIB) $(LS_LIB)
+libspiro_la_LDFLAGS = -no-undefined -version-info $(LIBSPIRO_VERSION)
+libspiro_la_SOURCES = spiro.c bezctx.c spiroentrypoints.c \
+	bezctx.h bezctx_intf.h spiro.h spiroentrypoints.h
 
 EXTRA_DIST = bezctx.md get-spiro-src.sh README-RaphLevien README.md	    \
 	closedspiro.png openspiro.png spiral16.png spiral32.png spiro-a.png \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,9 +3,9 @@ AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
 
 AM_CFLAGS = -I$(top_srcdir) -I$(top_builddir) $(DEP_CFLAGS) $(BABL_CFLAGS) -lm
 
-DEPS = $(top_builddir)/.libs/libspiro.la
+DEPS = $(top_builddir)/libspiro.la
 
-LDADDS = $(top_builddir)/.libs/libspiro.la
+LDADDS = $(top_builddir)/libspiro.la
 
 EXTRA_DIST = call-test.c
 


### PR DESCRIPTION
When building libspiro with slibtool (https://dev.midipix.org/cross/slibtool) it fails in two places.
```
rdlibtool --tag=CC --mode=link gcc -Wall -Wextra -Wcast-align -Wbad-function-cast -Wc++-compat -Wmissing-prototypes -Wunused -Wdeprecated-declarations -g -O2 -Wall -Wextra -Wcast-align -Wbad-function-cast -Wc++-compat -Wmissing-prototypes -Wunused -Wdeprecated-declarations -no-undefined --mode=link -version-info 1:1:0 -o libspiro.la -rpath /usr/local/lib spiro.lo bezctx.lo spiroentrypoints.lo -lm

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/libspiro"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 196675}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = 3.
rdlibtool: lconf: found "/tmp/libspiro/libtool".
rdlibtool: link: x86_64-pc-linux-gnu-ar crs .libs/libspiro.a .libs/spiro.o .libs/bezctx.o .libs/spiroentrypoints.o
rdlibtool: link: gcc .libs/spiro.o .libs/bezctx.o .libs/spiroentrypoints.o -Wall -Wextra -Wcast-align -Wbad-function-cast -Wc++-compat -Wmissing-prototypes -Wunused -Wdeprecated-declarations -g -O2 -Wall -Wextra -Wcast-align -Wbad-function-cast -Wc++-compat -Wmissing-prototypes -Wunused -Wdeprecated-declarations --mode=link -lm -shared -fPIC -Wl,--no-undefined -Wl,-soname -Wl,libspiro.so.1 -o .libs/libspiro.so.1.0.1
gcc: error: unrecognized command-line option ‘--mode=link’
rdlibtool: exec error upon slbt_exec_link_create_library(), line 1566: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1996.
make[1]: *** [Makefile:532: libspiro.la] Error 2
make[1]: Leaving directory '/tmp/libspiro'
make: *** [Makefile:672: install-recursive] Error 1
```
```
rdlibtool --tag=CC --mode=link gcc -I.. -I.. -lm -g -O2 -o call-test0 call-test0.o ../.libs/libspiro.la -lm

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/libspiro/tests"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 196774}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 196675}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/libspiro/libtool".
rdlibtool: error logged in slbt_get_deps_meta(), line 126: path not found: ../.libs/.libs/libspiro.a.slibtool.deps.
rdlibtool: < returned to > slbt_exec_link_create_executable(), line 1617.
rdlibtool: < returned to > slbt_exec_link(), line 2062.
make[1]: *** [Makefile:718: call-test0] Error 2
make[1]: Leaving directory '/tmp/libspiro/tests'
make: *** [Makefile:675: install-recursive] Error 1
```

This reveals four issues:

1. The build should not use `--mode=link` unless its also calling `$(LIBTOOL)` manually which its not. GNU libtool silently consumes and ignores invalid command-line arguments hiding the issue.
2. The build should link dependencies with `LIBADD` for libraries or `LDADD` for programs while `LDFLAGS` is for other linker arguments. GNU libtool is far more permissive about these things than slibtool and hides incorrect usage.
3. The header dependencies should be in `SOURCES` and the build should not define object files rules manually.
4. The `.libs` directory should not be manually added to the linker paths, that is for internal `$(LIBTOOL)` usage.

Also please see this related PR https://github.com/fontforge/libuninameslist/pull/24.